### PR TITLE
Add feature of kinsoku shori

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -125,7 +125,7 @@ export default {
   // runner: "jest-runner",
 
   // The paths to modules that run some code to configure or set up the testing environment before each test
-  // setupFiles: [],
+  setupFiles: ['jest-canvas-mock'],
 
   // A list of paths to modules that run some code to configure or set up the testing framework before each test
   // setupFilesAfterEnv: [],

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "eslint-plugin-prettier": "^3.1.4",
     "eslint-plugin-promise": "^4.2.1",
     "jest": "^26.6.3",
+    "jest-canvas-mock": "^2.3.0",
     "mkdirp": "^1.0.4",
     "pixi.js": "^5.3.3",
     "prettier": "^2.2.0",

--- a/package.json
+++ b/package.json
@@ -50,6 +50,9 @@
     "typescript": "^4.1.2",
     "watch": "^1.0.2"
   },
+  "peerDependencies": {
+    "pixi.js": "^5.3.3"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/huang-yuwei/pixi-cjk"

--- a/src/KinsokuShori.ts
+++ b/src/KinsokuShori.ts
@@ -1,0 +1,30 @@
+// Line breaking rules in CJK (Kinsoku Shori)
+// Refer from https://en.wikipedia.org/wiki/Line_breaking_rules_in_East_Asian_languages
+const regexCannotStartZhCn = /[!%),.:;?\]}¢°·'""†‡›℃∶、。〃〆〕〗〞﹚﹜！＂％＇），．：；？！］｝～]/;
+const regexCannotEndZhCn = /[$(£¥·'"〈《「『【〔〖〝﹙﹛＄（．［｛￡￥]/;
+const regexCannotStartZhTw = /[!),.:;?\]}¢·–— '"•" 、。〆〞〕〉》」︰︱︲︳﹐﹑﹒﹓﹔﹕﹖﹘﹚﹜！），．：；？︶︸︺︼︾﹀﹂﹗］｜｝､]/;
+const regexCannotEndZhTw = /[([{£¥'"‵〈《「『〔〝︴﹙﹛（｛︵︷︹︻︽︿﹁﹃﹏]/;
+const regexCannotStartJaJp = /[)\]｝〕〉》」』】〙〗〟'"｠»ヽヾーァィゥェォッャュョヮヵヶぁぃぅぇぉっゃゅょゎゕゖㇰㇱㇲㇳㇴㇵㇶㇷㇸㇹㇺㇻㇼㇽㇾㇿ々〻‐゠–〜? ! ‼ ⁇ ⁈ ⁉・、:;,。.]/;
+const regexCannotEndJaJp = /[([｛〔〈《「『【〘〖〝'"｟«—...‥〳〴〵]/;
+const regexCannotStartKoKr = /[!%),.:;?\]}¢°'"†‡℃〆〈《「『〕！％），．：；？］｝]/;
+const regexCannotEndKoKr = /[$([{£¥'"々〇〉》」〔＄（［｛｠￥￦ #]/;
+
+const regexCannotStart = new RegExp(
+  `${regexCannotStartZhCn.source}|${regexCannotStartZhTw.source}|${regexCannotStartJaJp.source}|${regexCannotStartKoKr.source}`,
+);
+const regexCannotEnd = new RegExp(
+  `${regexCannotEndZhCn.source}|${regexCannotEndZhTw.source}|${regexCannotEndJaJp.source}|${regexCannotEndKoKr.source}`,
+);
+
+export const canBreakChars = function canBreakChars(
+  char: string,
+  nextChar?: string,
+) {
+  if (nextChar) {
+    // Line breaking rules in CJK (Kinsoku Shori)
+    if (regexCannotEnd.exec(char) || regexCannotStart.exec(nextChar)) {
+      return false;
+    }
+  }
+  return true;
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
-export const testMethod = (a: number, b: number): number => {
-  return a + b;
-};
+import * as PIXI from 'pixi.js';
+import { canBreakChars } from './KinsokuShori';
+
+PIXI.TextMetrics.canBreakChars = canBreakChars;

--- a/test/KinsokuShori.test.ts
+++ b/test/KinsokuShori.test.ts
@@ -1,0 +1,113 @@
+import { canBreakChars } from '../src/KinsokuShori';
+
+describe('KinsokuShori', () => {
+  describe('Chinese', () => {
+    it('can break general chars', () => {
+      expect(canBreakChars('中')).toBeTruthy();
+
+      expect(canBreakChars('中', '文')).toBeTruthy();
+
+      expect(canBreakChars('。', '中')).toBeTruthy();
+
+      expect(canBreakChars('，', '中')).toBeTruthy();
+
+      expect(canBreakChars('；', '中')).toBeTruthy();
+    });
+
+    it('can not break when straring from the chars', () => {
+      expect(canBreakChars('文', '？')).toBeFalsy();
+
+      expect(canBreakChars('文', '」')).toBeFalsy();
+
+      expect(canBreakChars('文', '』')).toBeFalsy();
+
+      expect(canBreakChars('文', '"')).toBeFalsy();
+
+      expect(canBreakChars('文', '，')).toBeFalsy();
+
+      expect(canBreakChars('文', '。')).toBeFalsy();
+    });
+
+    it('can not break when ending to the chars', () => {
+      expect(canBreakChars('$', '中')).toBeFalsy();
+
+      expect(canBreakChars('「', '中')).toBeFalsy();
+
+      expect(canBreakChars('『', '中')).toBeFalsy();
+
+      expect(canBreakChars('"', '中')).toBeFalsy();
+    });
+  });
+
+  describe('Japanese', () => {
+    it('can break general chars', () => {
+      expect(canBreakChars('あ')).toBeTruthy();
+
+      expect(canBreakChars('あ', 'い')).toBeTruthy();
+
+      expect(canBreakChars('。', 'あ')).toBeTruthy();
+
+      expect(canBreakChars('、', 'あ')).toBeTruthy();
+
+      expect(canBreakChars('・', 'あ')).toBeTruthy();
+    });
+
+    it('can not break when straring from the chars', () => {
+      expect(canBreakChars('い', '？')).toBeFalsy();
+
+      expect(canBreakChars('い', '々')).toBeFalsy();
+
+      expect(canBreakChars('い', 'ー')).toBeFalsy();
+
+      expect(canBreakChars('い', 'ァ')).toBeFalsy();
+
+      expect(canBreakChars('い', 'ッ')).toBeFalsy();
+
+      expect(canBreakChars('い', '»')).toBeFalsy();
+    });
+
+    it('can not break when ending to the chars', () => {
+      expect(canBreakChars('$', 'あ')).toBeFalsy();
+
+      expect(canBreakChars('—', 'あ')).toBeFalsy();
+
+      expect(canBreakChars('«', 'あ')).toBeFalsy();
+    });
+  });
+
+  describe('Korean', () => {
+    it('can break general chars', () => {
+      expect(canBreakChars('한')).toBeTruthy();
+
+      expect(canBreakChars('한', '국')).toBeTruthy();
+
+      expect(canBreakChars(',', '한')).toBeTruthy();
+    });
+
+    it('can not break when straring from the chars', () => {
+      expect(canBreakChars('국', '?')).toBeFalsy();
+
+      expect(canBreakChars('국', '」')).toBeFalsy();
+
+      expect(canBreakChars('국', '%')).toBeFalsy();
+    });
+
+    it('can not break when ending to the chars', () => {
+      expect(canBreakChars('「', '한')).toBeFalsy();
+
+      expect(canBreakChars('『', '한')).toBeFalsy();
+
+      expect(canBreakChars('¥', '한')).toBeFalsy();
+    });
+  });
+
+  describe('Other languages', () => {
+    it('can break general chars', () => {
+      expect(canBreakChars('A')).toBeTruthy();
+
+      expect(canBreakChars('A', 'B')).toBeTruthy();
+
+      expect(canBreakChars(',', 'A')).toBeTruthy();
+    });
+  });
+});

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1,12 +1,82 @@
-import { testMethod } from '../src';
+import { TextStyle, TextMetrics } from 'pixi.js';
+import '../src';
 
-test('test for the testMethod', () => {
-  const subject = () => {
-    return testMethod(a, b);
-  };
+describe('PIXI.TextMetrics', () => {
+  const fontSize = 14;
 
-  const a = 1;
-  const b = 2;
+  // Mock canvas element
+  const createElement = document.createElement.bind(document);
+  const mockMeasureText = (text: string) => ({ width: text.length * fontSize });
+  const mockGetContext = () => ({ measureText: mockMeasureText });
 
-  expect(subject()).toBe(3);
+  document.createElement = jest.fn((tagName: string) => {
+    switch (tagName) {
+      case 'canvas':
+        return { getContext: mockGetContext };
+      default:
+        return createElement(tagName);
+    }
+  });
+  const canvas = document.createElement('canvas');
+
+  describe('canBreakChars', () => {
+    const style = new TextStyle({
+      fontWeight: 'bold',
+      fontSize: fontSize,
+      wordWrap: true,
+      breakWords: true,
+      wordWrapWidth: 340,
+    });
+
+    describe('Chinese', () => {
+      const beforePlugin = [
+        '你好，這是一篇測試文章，想確認這文章段落是否正常',
+        '?',
+      ];
+      const afterPlugin = [
+        '你好，這是一篇測試文章，想確認這文章段落是否正',
+        '常?',
+      ];
+      const source = beforePlugin.join('');
+
+      it('should break chars as rules', () => {
+        const { lines } = TextMetrics.measureText(source, style, true, canvas);
+        expect(lines).toStrictEqual(afterPlugin);
+      });
+    });
+
+    describe('Japanese', () => {
+      const beforePlugin = [
+        'こんにちは、これはテストの文章、正しく表示してる',
+        '?',
+      ];
+      const afterPlugin = [
+        'こんにちは、これはテストの文章、正しく表示して',
+        'る?',
+      ];
+      const source = beforePlugin.join('');
+
+      it('should break chars as rules', () => {
+        const { lines } = TextMetrics.measureText(source, style, true, canvas);
+        expect(lines).toStrictEqual(afterPlugin);
+      });
+    });
+
+    describe('Korean', () => {
+      const beforePlugin = [
+        '안녕하세요,이 테스트의 문장입니다 제대로 표시하고 있습니까',
+        '?',
+      ];
+      const afterPlugin = [
+        '안녕하세요,이 테스트의 문장입니다 제대로',
+        '표시하고 있습니까?',
+      ];
+      const source = beforePlugin.join('');
+
+      it('should break chars as rules', () => {
+        const { lines } = TextMetrics.measureText(source, style, true, canvas);
+        expect(lines).toStrictEqual(afterPlugin);
+      });
+    });
+  });
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,12 @@
+{
+	"compilerOptions": {
+		"target": "ES6",
+		"module": "commonjs",
+		"noImplicitAny": true,
+		"noEmit": true
+	},
+	"include": [
+    "src/*.ts",
+    "test/*.ts"
+	]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2157,7 +2157,7 @@ color-name@1.1.3:
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.3.tgz#a7d0558bd89c42f795dd42328f740831ca53bc25"
   integrity sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=
 
-color-name@~1.1.4:
+color-name@^1.1.4, color-name@~1.1.4:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.4.tgz#c2a09a87acbde69543de6f63fa3995c826c536a2"
   integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
@@ -2238,6 +2238,11 @@ cross-spawn@^7.0.0, cross-spawn@^7.0.2:
     path-key "^3.1.0"
     shebang-command "^2.0.0"
     which "^2.0.1"
+
+cssfontparser@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/cssfontparser/-/cssfontparser-1.2.1.tgz#f4022fc8f9700c68029d542084afbaf425a3f3e3"
+  integrity sha1-9AIvyPlwDGgCnVQghK+69CWj8+M=
 
 cssom@^0.4.4:
   version "0.4.4"
@@ -3653,6 +3658,14 @@ istanbul-reports@^3.0.2:
     html-escaper "^2.0.0"
     istanbul-lib-report "^3.0.0"
 
+jest-canvas-mock@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/jest-canvas-mock/-/jest-canvas-mock-2.3.0.tgz#50f4cc178ae52c4c0e2ce4fd3a3ad2a41ad4eb36"
+  integrity sha512-3TMyR66VG2MzAW8Negzec03bbcIjVJMfGNvKzrEnbws1CYKqMNkvIJ8LbkoGYfp42tKqDmhIpQq3v+MNLW2A2w==
+  dependencies:
+    cssfontparser "^1.2.1"
+    moo-color "^1.0.2"
+
 jest-changed-files@^26.6.2:
   version "26.6.2"
   resolved "https://registry.yarnpkg.com/jest-changed-files/-/jest-changed-files-26.6.2.tgz#f6198479e1cc66f22f9ae1e22acaa0b429c042d0"
@@ -4382,6 +4395,13 @@ mkdirp@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-1.0.4.tgz#3eb5ed62622756d79a5f0e2a221dfebad75c2f7e"
   integrity sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==
+
+moo-color@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/moo-color/-/moo-color-1.0.2.tgz#837c40758d2d58763825d1359a84e330531eca64"
+  integrity sha512-5iXz5n9LWQzx/C2WesGFfpE6RLamzdHwsn3KpfzShwbfIqs7stnoEpaNErf/7+3mbxwZ4s8Foq7I0tPxw7BWHg==
+  dependencies:
+    color-name "^1.1.4"
 
 ms@2.0.0:
   version "2.0.0"


### PR DESCRIPTION
# Why
- apply the Kinsoku Shori feature

# Summary
- blocking the chars that cannot start or end by following the rules in East Asian languages
- apply the canvas mockup for testing the PIXI related features

# Testing
- check whether the lines breaking follows the rules

# Related Links
- https://en.wikipedia.org/wiki/Line_breaking_rules_in_East_Asian_languages

# Screenshots
BEFORE
<img width="333" alt="スクリーンショット 2020-11-28 23 59 07" src="https://user-images.githubusercontent.com/44968790/100518580-c6eabe00-31d5-11eb-9a16-f47c4ddfa559.png">

AFTER
<img width="334" alt="スクリーンショット 2020-11-28 23 58 51" src="https://user-images.githubusercontent.com/44968790/100518582-cb16db80-31d5-11eb-9960-b0cc83aff147.png">

![image](https://user-images.githubusercontent.com/44968790/100518616-ef72b800-31d5-11eb-8145-b708728efdc7.png)

# Note
Korean doesn't work correctly because the space breaking rules haven't applied. Will fix it in the next PR.