### PR TITLE
Fix wordwrap of emoji

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pixi-cjk",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "CJK supporting for Pixi.js",
   "author": "Yuwei Huang <yuwei.h.design@gmail.com>",
   "main": "bin/pixi-cjk.min.js",

--- a/src/index.ts
+++ b/src/index.ts
@@ -40,7 +40,7 @@ PIXI.TextMetrics.wordWrap = function (
       return;
     }
 
-    if (currentWidth + width > maxWidth) {
+    if (currentWidth > 0 && currentWidth + width > maxWidth) {
       currentIndex++;
       currentWidth = 0;
       lines[currentIndex] = '';

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,8 +28,7 @@ PIXI.TextMetrics.wordWrap = function (
     return this.getFromCache(char, letterSpacing, cache, context);
   };
 
-  for (let i = 0; i < text.length; i++) {
-    const char = text[i];
+  Array.from(text).forEach((char, i) => {
     const prevChar = text[i - 1];
     const nextChar = text[i + 1];
     const width = calcWidth(char);
@@ -38,7 +37,7 @@ PIXI.TextMetrics.wordWrap = function (
       currentIndex++;
       currentWidth = 0;
       lines[currentIndex] = '';
-      continue;
+      return;
     }
 
     if (currentWidth + width > maxWidth) {
@@ -47,7 +46,7 @@ PIXI.TextMetrics.wordWrap = function (
       lines[currentIndex] = '';
 
       if (this.isBreakingSpace(char)) {
-        continue;
+        return;
       }
 
       if (!canBreakInLastChar(char)) {
@@ -63,6 +62,6 @@ PIXI.TextMetrics.wordWrap = function (
 
     currentWidth += width;
     lines[currentIndex] = (lines[currentIndex] || '') + char;
-  }
+  });
   return lines.join('\n');
 };

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -4,13 +4,7 @@ import '../src';
 describe('PIXI.TextMetrics', () => {
   const fontSize = 14;
   // Generate Text style
-  const style = new TextStyle({
-    fontWeight: 'bold',
-    fontSize: fontSize,
-    wordWrap: true,
-    breakWords: true,
-    wordWrapWidth: 340,
-  });
+  let style: TextStyle;
 
   // Mock canvas element
   const createElement = document.createElement.bind(document);
@@ -34,6 +28,16 @@ describe('PIXI.TextMetrics', () => {
     const { lines } = TextMetrics.measureText(source, style, true, canvas);
     return lines;
   };
+
+  beforeEach(() => {
+    style = new TextStyle({
+      fontWeight: 'bold',
+      fontSize: fontSize,
+      wordWrap: true,
+      breakWords: true,
+      wordWrapWidth: 340,
+    });
+  });
 
   describe('Kinsoku-Shorui in text metrics', () => {
     describe('Chinese', () => {
@@ -218,6 +222,17 @@ ${beforePlugin[1]}`;
     it('should return a valid strings', () => {
       const beforePlugin = ['你好，這是一篇測試文章，想確認這文章段落是否正常'];
       const afterPlugin = ['你好，這是一篇測試文章，想確認這文章段落是否正常'];
+
+      const source = beforePlugin.join('');
+      expect(subject(source, mockCanvas)).toStrictEqual(afterPlugin);
+    });
+  });
+
+  describe('string contains emoji chars', () => {
+    it('should return a valid strings', () => {
+      const beforePlugin = ['🚀'];
+      const afterPlugin = ['🚀'];
+      style.wordWrapWidth = 25;
 
       const source = beforePlugin.join('');
       expect(subject(source, mockCanvas)).toStrictEqual(afterPlugin);


### PR DESCRIPTION
# Why
- fix the bug of breaking emoji into pieces

# Summary
- loop the text by using array loop (refer from https://medium.com/@giltayar/iterating-over-emoji-characters-the-es6-way-f06e4589516)
- prevent additional breaks when the char is smaller than min-width

# Testing
- check whether the one char line breaks the line (which should not)
- check whether the emoji line remains the same

# Screenshots
### Before
![7041d04e46af9ef3d9e6b61283456ae8](https://user-images.githubusercontent.com/44968790/109495563-cd3d4e80-7ad2-11eb-8023-a36181c50bc3.gif)

### After
![dd5af3d1b4c4d7a73796664d03ac797a](https://user-images.githubusercontent.com/44968790/109495850-2efdb880-7ad3-11eb-9954-c7fb88994199.gif)
